### PR TITLE
Read price minimal

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,8 @@
+"use strict";
+
+document.addEventListener("load", printPrice, true);;
+
+function printPrice() {
+    let price = document.querySelector("[data-automation-id='productPage'] [data-automation-id='salePrice']").textContent;
+    console.log("price = " + price);
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,15 +1,63 @@
 "use strict";
+document.addEventListener("load", scrapeProduct, {capture: true});
 
-document.addEventListener("load", printPrice, {capture: true});
+function scrapeProduct() {
+    if (document.readyState !== "complete") {
+        return;
+    }
 
-function printPrice() {
-    if (document.readyState === "complete") {
-        console.log(document.readyState);
-        let price_elem = document.querySelector("[data-automation-id='productPage'] [data-automation-id='salePrice']")
-        if (!price_elem) {console.log("page not loaded yet");}
-        else {
-            let price = price_elem.textContent;
-            console.log("price = " + price);
-        }
+    let product_elem = document.querySelector("[data-automation-id='productPage']");
+    if (!product_elem) {
+        //console.log("product page not loaded yet.");
+        return;
+    }
+    let price = getPrice();
+    // Validate price $ + format.
+    // Check if blank or invalid
+
+    let unit_price = getUnitPrice()
+    // Validate unit price $ + format.
+    // Check if blank or invalid
+
+    let productData = {
+        total_price: price,
+        unit_price: unit_price,
+//        date_recorded: (new Date()).toUTCString(),
+        date_recorded: (new Date()).toDateString(),
+
+    }
+    let json_product_data = JSON.stringify(productData);
+    console.log(json_product_data);
+}
+
+/**
+ * Returns the product price
+ * @returns {String} price in form $1.98
+ *
+ */
+function getPrice() {
+    let price_elem = document.querySelector("[data-automation-id='productPage'] [data-automation-id='salePrice']");
+    if (!price_elem) {console.log("Price not loaded on page yet");}
+    else {
+        return price_elem.textContent;
     }
 }
+
+/**
+ * Returns the product unit price (ex. 5/oz)
+ * @returns {String} unit price in form 0.53[cents]/unit
+ */
+function getUnitPrice() {
+    let unit_elem = document.querySelector("[data-automation-id='productPage'] [data-automation-id='price-per-unit']");
+
+    // element exists check
+    if (!unit_elem) {
+        return;
+    }
+
+    return unit_elem.textContent;
+
+}
+
+// TODO: Figure out what event can distingush when a new product has finished loading from an existing page.
+// A counter will not work, as it only works when the

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,8 +1,15 @@
 "use strict";
 
-document.addEventListener("load", printPrice, true);;
+document.addEventListener("load", printPrice, {capture: true});
 
 function printPrice() {
-    let price = document.querySelector("[data-automation-id='productPage'] [data-automation-id='salePrice']").textContent;
-    console.log("price = " + price);
+    if (document.readyState === "complete") {
+        console.log(document.readyState);
+        let price_elem = document.querySelector("[data-automation-id='productPage'] [data-automation-id='salePrice']")
+        if (!price_elem) {console.log("page not loaded yet");}
+        else {
+            let price = price_elem.textContent;
+            console.log("price = " + price);
+        }
+    }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Grocery price tracker",
+  "version": "0.0.5",
+  "description": "Tracks prices of groceries over time.",
+  "content_scripts": [
+   {
+     "matches": ["https://*.walmart.com/*"],
+     "js": ["content.js"]
+   }
+ ],
+ "permissions": [
+   "activeTab",
+   "declarativeContent"
+ ],
+ "background": {
+    "scripts": [
+      "background.js"
+    ],
+    "persistent": false
+ },
+  "manifest_version": 2
+}
+

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,16 +1,22 @@
 {
   "name": "Grocery price tracker",
-  "version": "0.0.6",
+  "version": "0.0.10",
   "description": "Tracks prices of groceries over time.",
   "content_scripts": [
    {
-     "matches": ["https://*.walmart.com/*"],
-     "js": ["content.js"]
+     "all_frames": false,
+     "matches": ["*://*.walmart.com/*"],
+     "js": ["content.js"],
+     "run_at": "document_start"
    }
  ],
  "permissions": [
    "activeTab",
-   "declarativeContent"
+   "declarativeContent",
+   "tabs",
+   "storage",
+   "*://walmart.com/*",
+   "*://walmart.com/v3/api/products/*"
  ],
  "background": {
     "scripts": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Grocery price tracker",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Tracks prices of groceries over time.",
   "content_scripts": [
    {


### PR DESCRIPTION
Captures minimal Walmart Groceries's product page info.

Currently captures, `price`, `unit_price`, and what day it was captured.

Logs to JS console for now.

There are currently there are a few bugs.

1. The price capture function is firing on every resource load <so, like 40-66 times>
2. The `price-per-unit` automation-id sometimes has two items to it. Need to combine them together and process apart the qty / unit.