### PR TITLE
Simplify and make no extra requests + fix extension not loading on tab reopen

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -40,27 +40,7 @@ class Price {
     }
 }
 
-//Todo: Get sample fn working on content page reopen
 
-window.addEventListener("unload", function() {
-    chrome.debugger.detach({tabId:tabId});
-    gAttached = false;
-    console.log("unloaded");
-});
-
-
-// Attach debugger every time a tab is updated.
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-    if (changeInfo.status !== "complete") {
-        return;
-    }
-
-    let debuggee = {tabId: tabId};
-    chrome.debugger.onEvent.addListener(initialListener);
-});
-
-
-// Below copied from: https://stackoverflow.com/questions/47962104/chrome-extension-no-resource-with-given-identifier-found-when-trying-to-netwo
 
 let gAttached = false;
 let gRequests = [];

--- a/extension/background.js
+++ b/extension/background.js
@@ -148,8 +148,6 @@ function initialListener(details) {
             }, "Network.enable");
         });
         console.debug("attached inner debugger");
-        // Remove self since the debugger is attached already
-        //chrome.webRequest.onBeforeRequest.removeListener(initialListener);
     }
     console.debug(`exit initialListener: tabID=${details.tabId}, gAttached=${gAttached}`);
 
@@ -168,13 +166,10 @@ chrome.runtime.onMessage.addListener(
     });
 
 
-// Attach debugger on startup
-//chrome.webRequest.onBeforeRequest.addListener(initialListener, {urls: ["<all_urls>"]}, ["blocking"]);
-
 // Filter if the url is what we want
 function getTarget(url) {
     for (const i in TARGETS) {
-        var target = TARGETS[i];
+        let target = TARGETS[i];
         if (url.match(target.url)) {
             return i;
         }

--- a/extension/background.js
+++ b/extension/background.js
@@ -41,6 +41,7 @@ class Price {
 }
 
 
+// Below adapted from: https://stackoverflow.com/questions/47962104/chrome-extension-no-resource-with-given-identifier-found-when-trying-to-netwo
 
 let gAttached = false;
 let gRequests = [];

--- a/extension/background.js
+++ b/extension/background.js
@@ -89,7 +89,8 @@ chrome.debugger.onEvent.addListener(function (source, method, params) {
                 function (response) {
                     if (response) {
                         console.log("response for url:", object.url);
-                        console.log(response);
+                        let resp_json = JSON.parse(response.body);
+                        parseProductJson(resp_json);
                     } else {
                         console.log("Empty response for " + object.url);
                     }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,4 +1,16 @@
 "use strict";
+
+window.addEventListener("unload", function() {
+        let currTab = tabs[0];
+        if (currTab) { // Sanity check
+            chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+                chrome.debugger.detach({tabId:currTab.id});
+                console.log("detached debugger from tab id:", currTab.id);
+            });
+        }
+});
+
+
 // Attach debugger every time a tab is updated.
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
     if (changeInfo.status !== "complete") {
@@ -11,6 +23,10 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
     chrome.debugger.onEvent.addListener(onEvent);
 });
 
+
+//requestIds
+let pendingRequests = [];
+
 /**
  * Handles any events that are triggered by Chrome debugger
  * @param debuggeeId {chrome.debugger.types.Debuggee} Most concenred with tabId (for content tab)
@@ -18,19 +34,48 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
  * @param params {Object} JSON object with the parameters. Structure of the parameters varies depending on the method name and is defined by the 'parameters' attribute of the event description in the remote debugging protocol.
  */
 function onEvent(debuggeeId, message, params) {
+
+    //console.log("got event", message, params);
     if (message == "Network.responseReceived") {
         if (params.response.url.includes("grocery.walmart.com/v3/api/products")) {
+            //console.log(debuggeeId, message, params);
+            pendingRequests.push(params.requestId);
+            //console.log("saved pending requestID:", params.requestId);
+        }
+    }
+    else if (message == "Network.loadingFinished") {
+        //console.log("loading event:", message, params);
+        let indexOrNot = pendingRequests.indexOf(params.requestId);
+        if (indexOrNot === -1) {
+            return;
+        }
+        // Got a grocery price request
+        let neededRequestId = pendingRequests[indexOrNot];
+
+        // Check if the loadingFinished event is for this request
+        if (neededRequestId !== params.requestId) {
+            console.log(`pendingRequestID ${neededRequestId} !== ${params.requestId} loadFinished requestId`);
+            return;
+        }
 
             // Copied from: https://stackoverflow.com/questions/48785946/how-to-get-response-body-of-all-requests-made-in-a-chrome-extension
+        // encoded data length is -1 or 0
+        console.log("requesting response for requestID:", neededRequestId);
             chrome.debugger.sendCommand({
                 tabId: debuggeeId.tabId
             }, "Network.getResponseBody", {
-                "requestId": params.requestId
+                "requestId": neededRequestId
             }, function (response) {
+
+                if (!response) {
+                    console.log("no response", response);
+                    return;
+                }
+                console.log("captured resp:", response);
                 let response_json = JSON.parse(response.body);
                 parseProductJson(response_json);
-            });
-        }
+            })
+        pendingRequests.splice(indexOrNot, 1);
     }
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,1 +1,6 @@
 "use strict";
+
+// Have the bg script attach the debugger every time the page loads
+chrome.runtime.sendMessage({message: "attachDebugger"}, (response) => {
+    console.log(response.message);
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,8 +6,7 @@
    {
      "all_frames": false,
      "matches": ["*://*.walmart.com/*"],
-     "js": ["content.js"],
-     "run_at": "document_start"
+     "js": ["content.js"]
    }
  ],
  "permissions": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Grocery price tracker",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "Tracks prices of groceries over time.",
   "content_scripts": [
    {
@@ -16,7 +16,6 @@
    "tabs",
    "storage",
    "debugger",
-   "webRequest",
    "*://*.walmart.com/*",
    "*://*.walmart.com/v3/api/products/*"
  ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,6 @@
  ],
  "permissions": [
    "activeTab",
-   "declarativeContent",
    "tabs",
    "storage",
    "debugger",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Grocery price tracker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Tracks prices of groceries over time.",
   "content_scripts": [
    {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,8 +12,6 @@
  ],
  "permissions": [
    "activeTab",
-   "webRequest",
-   "webRequestBlocking",
    "declarativeContent",
    "tabs",
    "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Grocery price tracker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Tracks prices of groceries over time.",
   "content_scripts": [
    {
@@ -12,6 +12,8 @@
  ],
  "permissions": [
    "activeTab",
+   "webRequest",
+   "webRequestBlocking",
    "declarativeContent",
    "tabs",
    "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,7 +23,7 @@
     "scripts": [
       "background.js"
     ],
-    "persistent": true
+    "persistent": false
  },
   "manifest_version": 2
 }


### PR DESCRIPTION
The extension now makes no requests to any of servers we got info from.

Adapted from: https://stackoverflow.com/questions/47962104/chrome-extension-no-resource-with-given-identifier-found-when-trying-to-netwo


# Fixing debugger not reattaching on tab reopen
The content script now sends a message to the background script to reattach the debugger.

# Dropping permissions
This means that `webRequest`, `webRequestBlocking` can be dropped from permissions.
Also, the background page now works without needing to be persistent. Yay!.

Drop `declaritveContent` as it was never used.